### PR TITLE
enable and fix pedantic warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,12 @@ if(WITH_ATLTileCalTB_NoNoise)
 endif()
 
 #----------------------------------------------------------------------------
+# Output pedantic warnings
+#
+
+add_compile_options(-Wall -Wextra -Wpedantic)
+
+#----------------------------------------------------------------------------
 # Setup Geant4 include directories and compile definitions
 # Setup include directory for this project
 #

--- a/include/ATLTileCalTBConstants.hh
+++ b/include/ATLTileCalTBConstants.hh
@@ -452,7 +452,7 @@ namespace ATLTileCalTBConstants {
         0.00185470,
     };
 
-};
+}
 
 #endif //ATLTileCalTBConstants_h
 

--- a/include/ATLTileCalTBGeometry.hh
+++ b/include/ATLTileCalTBGeometry.hh
@@ -203,7 +203,7 @@ namespace ATLTileCalTBGeometry {
             void operator=(CellLUT const&) = delete;
     };
 
-};
+}
 
 #endif //ATLTileCalTBGeometry_h
 

--- a/include/ATLTileCalTBHit.hh
+++ b/include/ATLTileCalTBHit.hh
@@ -66,22 +66,22 @@ class ATLTileCalTBHit : public G4VHit {
 
 using ATLTileCalTBHitsCollection = G4THitsCollection<ATLTileCalTBHit>;
 
-inline void ATLTileCalTBHit::AddEdep(G4double dEdep) { fEdep += dEdep; };
+inline void ATLTileCalTBHit::AddEdep(G4double dEdep) { fEdep += dEdep; }
 
 inline void ATLTileCalTBHit::AddSdep(std::size_t index, G4double dSdepUp, G4double dSdepDown) {
     fSdepUp[index] += dSdepUp;
     fSdepDown[index] += dSdepDown;
-};
+}
 
 inline void ATLTileCalTBHit::AddSdep(G4double time, G4double dSdepUp, G4double dSdepDown) {
     AddSdep(GetBinFromTime(time), dSdepUp, dSdepDown);
 }
 
-inline G4double ATLTileCalTBHit::GetEdep() const { return fEdep; };
+inline G4double ATLTileCalTBHit::GetEdep() const { return fEdep; }
 
-inline const std::array<G4double, ATLTileCalTBConstants::frames>& ATLTileCalTBHit::GetSdepUp() const { return fSdepUp; };
+inline const std::array<G4double, ATLTileCalTBConstants::frames>& ATLTileCalTBHit::GetSdepUp() const { return fSdepUp; }
 
-inline const std::array<G4double, ATLTileCalTBConstants::frames>& ATLTileCalTBHit::GetSdepDown() const { return fSdepDown; };
+inline const std::array<G4double, ATLTileCalTBConstants::frames>& ATLTileCalTBHit::GetSdepDown() const { return fSdepDown; }
 
 #endif //ATLTileCalTBHit_h 1
 


### PR DESCRIPTION
These warnings appear with GCC10, mostly superfluous semicolons. This PR ensure pedantic warnings are enabled and also fixes them.