### PR TITLE
minor performance optimizations

### DIFF
--- a/src/ATLTileCalTBEventAction.cc
+++ b/src/ATLTileCalTBEventAction.cc
@@ -108,9 +108,9 @@ void ATLTileCalTBEventAction::EndOfEventAction( const G4Event* event ) {
             G4double outsum = 0.;
             auto jmax = (k >= pmt_response_size) ? pmt_response_size - 1 : k;
             for (std::size_t j = 0; j <= jmax; ++j) {
-                outsum += sdep.at(k - j) * ATLTileCalTBConstants::pmt_response.at(j);
+                outsum += sdep[k - j] * ATLTileCalTBConstants::pmt_response[j];
             }
-            outvec.at(k) = outsum;
+            outvec[k] = outsum;
         }
         return outvec;
     };

--- a/src/ATLTileCalTBRunAction.cc
+++ b/src/ATLTileCalTBRunAction.cc
@@ -36,7 +36,7 @@ ATLTileCalTBRunAction::ATLTileCalTBRunAction( ATLTileCalTBEventAction* eventActi
     
     //Printing event number per each event
     //
-    G4RunManager::GetRunManager()->SetPrintProgress(1);     
+    G4RunManager::GetRunManager()->SetPrintProgress(100);
 
     //Get analysis manager
     //


### PR DESCRIPTION
- faster PMT response by using `operator[]` instead of `at()` -> no boundary checking means compiler can vectorize
- less progress printing (every 100th event is frequent enough)