### PR TITLE
Add Fluka.Cern interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,11 +56,39 @@ add_compile_options(-Wall -Wextra -Wpedantic)
 include(${Geant4_USE_FILE})
 
 #----------------------------------------------------------------------------
+# Find FLUKA interface (optional) and add relative compile definitions.
+# (this part is taken from /examples/extended/hadronic/FLUKACern/FlukaInterface/README.md
+# as in geant4-11.1.ref05 (May 2023))
+# FindFLUKAInterface.cmake is located at your_path_to_geant4/cmake/Modules/FindFLUKAInterface.cmake
+# Check that FindFLUKAInterface.cmake can be found from $CMAKE_MODULE_PATH
+message(STATUS "CMAKE_MODULE_PATH = ${CMAKE_MODULE_PATH}")
+# Otherwise, you can always prepend it to the cmake module search path with:
+# set(CMAKE_MODULE_PATH my_path_to_find_fluka ${CMAKE_MODULE_PATH})
+
+# Check whether FLUKA should be used or not
+set(G4_USE_FLUKA OFF CACHE BOOL "Using FLUKA")
+if(G4_USE_FLUKA)
+  message(STATUS "G4_USE_FLUKA=ON : Using FLUKA interface for building ${PROJECT_SOURCE_DIR}")
+  add_definitions(-DG4_USE_FLUKA)
+  find_package(FLUKAInterface REQUIRED)
+  if(FLUKAInterface_FOUND)
+    message(STATUS "FLUKA cmake module was found : ${CMAKE_MODULE_PATH}")
+  else()
+    message(FATAL_ERROR "FLUKA cmake module was NOT found! Please add one.")
+  endif()
+else()
+  message(STATUS "G4_USE_FLUKA=OFF : NOT using FLUKA interface for building ${PROJECT_SOURCE_DIR}. \n \
+  If ever you want to use the FLUKA interface, please repeat cmake command with -DG4_USE_FLUKA=1")
+endif()
+#End of find FLUKAInterface
+
+#----------------------------------------------------------------------------
 # Locate sources and headers for this project
 # NB: headers are included so they will show up in IDEs
 #
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include
-                    ${Geant4_INCLUDE_DIR})
+                    ${Geant4_INCLUDE_DIR}
+		    ${FLUKAInterface_INCLUDE_DIR})
 file(GLOB sources ${PROJECT_SOURCE_DIR}/src/*.cc)
 file(GLOB headers ${PROJECT_SOURCE_DIR}/include/*.hh)
 
@@ -68,7 +96,7 @@ file(GLOB headers ${PROJECT_SOURCE_DIR}/include/*.hh)
 # Add the executable, and link it to the Geant4 libraries
 #
 add_executable(ATLTileCalTB ATLTileCalTB.cc ${sources} ${headers})
-target_link_libraries(ATLTileCalTB ${Geant4_LIBRARIES})
+target_link_libraries(ATLTileCalTB ${Geant4_LIBRARIES} ${FLUKAInterface_LIBRARIES})
 set_target_properties(ATLTileCalTB PROPERTIES CXX_STANDARD 17)
 
 #----------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,7 @@ install(TARGETS ATLTileCalTB DESTINATION bin)
 #----------------------------------------------------------------------------
 # Add analysis
 #
-option(BUILD_ANALYSIS "build analysis (requires ROOT)" ON)
+option(BUILD_ANALYSIS "build analysis (requires ROOT)" OFF)
 if(BUILD_ANALYSIS)
   add_subdirectory(analysis)
 endif()

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The project targets a standalone Geant4 simulation of the ATLAS Tile Calorimeter
 ### Available datasets and analyses
 We provide datasets and ROOT analyses, as well as instructions for their reproducibility.
 Ask authors for access to datasets. Results are deployed on Geant Val.
-<details><summary>Results-Table</summary>
+<details><summary>Geant-val-results-table</summary>
 <p>
 
 | ATLTileCalTB     | Reproduce data | Reproduce analysis | Comments     |
@@ -75,6 +75,14 @@ Ask authors for access to datasets. Results are deployed on Geant Val.
 | v1.1 <br /> Geant4 11.1.p01 <br /> tag 1.1_2 <br /> FTFP_INCLXX Added 2/5/2023 | Run with Geant Val, OR <br /> `./ATLTileCalTB -m TBrun_all.mac -p $PHYSLIST` | Run with Geant Val, OR <br /> `root ../analysis/TBrun_all.C` | FTFP_INCLXX results only because results 1.1_1 do not contain FTFP_INCLXX |
 | v1.1 <br /> Geant4 11.1 <br /> tag 1.1_1 <br /> FTFP_BERT(+tunes1,2,3), FTFP_BERT_ATL, QGSP_BERT (tag v1.1_1) <br /> 300k events per run <br /> Added 13/2/2023 | Run with Geant Val, OR <br /> `./ATLTileCalTB -m TBrun_all.mac -p $PHYSLIST` | Run with Geant Val, OR <br /> `root ../analysis/TBrun_all.C` | FTFP_INCLXX results not included due to a crash, to be investigated (problem with merged root files by parser.py) |
 | v1.0 <br /> Geant4 10.4.p03, 10.5.p01, 10.6.p03, 10.7.p03, 11.0.p02 <br /> FTFP_BERT, FTFP_BERT_ATL, QGSP_BERT, FTFP_INCLXX <br /> 300k events per run <br /> Added 17/8/2022 | Run with Geant Val, OR <br /> `./ATLTileCalTB -m TBrun_all.mac -p $PHYSLIST` | Run with Geant Val, OR <br /> `root ../analysis/TBrun_all.C` | Adjusted events per run to 300k |
+</p>
+</details>
+<details><summary>Other-results-table</summary>
+<p>
+
+| ATLTileCalTB     | Reproduce data | Reproduce analysis | Comments     |
+| -------------    | ----------     | -----------        | -----------  |
+|                  |                |                    |              |
 </p>
 </details>
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A Geant4 simulation of the ATLAS Tile Calorimeter beam tests.
         <li><a href="#build-compile-and-execute-on-maclinux">Build, compile and execute on Mac/Linux</a></li>
         <li><a href="#build-compile-and-execute-on-lxplus">Build, compile and execute on lxplus</a></li>
         <li><a href="#submit-a-job-with-htcondor-on-lxplus">Submit a job with HTCondor on lxplus</a></li>
+        <li><a href="#use-flukacern-hadron-inelastic-process">Use Fluka.Cern hadron inelastic process</a></li>
       </ul>
     </li>
     <li><a href="#geant-val-integration">Geant Val integration</a></li>
@@ -179,6 +180,34 @@ Parser options
    condor_ssh_to_job jobid.0
    ```
 
+### Use Fluka.Cern hadron inelastic process
+`Geant4-11.1-ref05` introduces a Fluka.Cern interface to use the Fluka.Cern hadron inelastic process in any geant4 application as explained in `examples/extended/hadronic/FlukaCern`. The following are my instructions to use this repo with a customized FTFP_BERT physics list using it. It assumes that cvmfs is mounted (e.g. usage on lxplus).
+1. Install Fluka.Cern from source code (example with fluka4-3.3)
+   ```sh
+   source /cvmfs/sft.cern.ch/lcg/contrib/gcc/10.1.0/x86_64-centos7/setup.sh
+   cd fluka4-3.3 && make -j 4
+   cd src/ && make cpp_headers
+   mkdir /path-to/fluka4-3.3-install && make install DESTDIR=/path-to/fluka4-3.3-install/
+   PATH="/absolute-path-to/fluka4-3.3-install/bin/":$PATH
+   ```
+2. Setup `geant4-11.1.ref05` and compile the fluka interface as in the example
+   ```sh
+   source /cvmfs/geant4.cern.ch/geant4/11.1.ref05/x86_64-centos7-gcc10-optdeb-MT/CMake-setup.sh 
+   source /cvmfs/geant4.cern.ch/geant4/11.1.ref05/x86_64-centos7-gcc10-optdeb-MT/bin/geant4.sh 
+   cd FlukaCern/FlukaInterface/
+   make interface
+   make env
+   source env_FLUKA_G4_interface.sh 
+   ```
+3. Build and execute ATLTileCalTB
+   ```sh
+   git clone https://github.com/lopezzot/ATLTileCalTB.git
+   mkdir ATLTileCalTB-build && cd ATLTileCalTB-build
+   /cvmfs/sft.cern.ch/lcg/contrib/CMake/3.23.2/Linux-x86_64/bin/cmake -DG4_USE_FLUKA=1 ../ATLTileCalTB/
+   make
+   ```
+   NOTE: the Fluka.Cern interface can only be used in single-threaded mode.
+
 <!--Geant Val integration-->
 ## Geant Val integration
 [Geant Val](https://geant-val.cern.ch/) is the Geant4 testing and validation suite. It is a project hosted on [gitlab.cern.ch](https://gitlab.cern.ch/GeantValidation) used to facilitate the maintenance and validation of Geant4 applications, referred to as <em>tests</em>.\
@@ -249,6 +278,7 @@ Custom options:
 -  `WITH_ATLTileCalTB_NoNoise`: if set to `ON`, the simulation will not put electronic noise on the
    signal (per cell) and disable the 2 sigma noise cut. Only relevant for noise calibration.
 -  `WITH_GEANT4_UIVIS`: if set to `ON` (default), build with UI and visualization drivers.
+-   `G4_USE_FLUKA`: if set to `ON` build against the Fluka.Cern interface (default `OFF`).
 
 Relevant built-in options:
 -  `CMAKE_BUILD_TYPE`: set to `Debug` for debugging and to `Release` for production (faster).

--- a/include/FLUKAHadronInelasticPhysics.hh
+++ b/include/FLUKAHadronInelasticPhysics.hh
@@ -1,0 +1,52 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+// Construct hadron inelastic physics processes with FLUKA.CERN XS and models.
+//
+// Author: G.Hugo, 01 August 2022
+//
+// History: L. Pezzotti adaption of the FLUKAHadronInelasticPhysicsConstructor
+// by G. Hugo to not include the HP treatment for neutrons. (June 6, 2023)
+// ***************************************************************************
+#ifdef G4_USE_FLUKA
+#ifndef FLUKA_HADRON_INELASTIC_PHYSICS_HH
+#define FLUKA_HADRON_INELASTIC_PHYSICS_HH 1
+
+// G4
+#include "G4VPhysicsConstructor.hh"
+
+class FLUKAHadronInelasticPhysics final : public G4VPhysicsConstructor {
+
+public:
+  FLUKAHadronInelasticPhysics(G4int verbose = 1);
+
+  virtual void ConstructParticle() override;
+  virtual void ConstructProcess() override;
+
+};
+
+
+#endif // FLUKA_HADRON_INELASTIC_PHYSICS_HH
+#endif // G4_USE_FLUKA

--- a/include/G4_CernFLUKAHadronInelastic_FTFP_BERT.hh
+++ b/include/G4_CernFLUKAHadronInelastic_FTFP_BERT.hh
@@ -1,0 +1,39 @@
+//**************************************************
+// \file G4_CernFLUKAHadronInelastic_FTFP_BERT.hh
+// \brief: Definition
+// G4_CernFLUKAHadronInelastic_FTFP_BERT.hh class
+// \author: Lorenzo Pezzotti (CERN EP-SFT-sim)
+//          @lopezzot
+// \start date: 2 June 2023
+//**************************************************
+
+/*Note:
+This class is a customization of the FTFP_BERT physics list
+to use the HadronInelastic process of FLUKA via the
+FLUKA interface included in geant4-11.1.ref05.
+*/
+
+#ifdef G4_USE_FLUKA
+#  ifndef G4_CernFLUKAHadronInelastic_FTFP_BERT_h
+#    define G4_CernFLUKAHadronInelastic_FTFP_BERT_h 1
+
+#    include "G4VModularPhysicsList.hh"
+#    include "globals.hh"
+
+#    include <CLHEP/Units/SystemOfUnits.h>
+
+class G4_CernFLUKAHadronInelastic_FTFP_BERT final : public G4VModularPhysicsList
+{
+  public:
+    G4_CernFLUKAHadronInelastic_FTFP_BERT(G4int ver = 1);
+    virtual ~G4_CernFLUKAHadronInelastic_FTFP_BERT() = default;
+
+    G4_CernFLUKAHadronInelastic_FTFP_BERT(const G4_CernFLUKAHadronInelastic_FTFP_BERT&) = delete;
+    G4_CernFLUKAHadronInelastic_FTFP_BERT&
+    operator=(const G4_CernFLUKAHadronInelastic_FTFP_BERT&) = delete;
+};
+
+#  endif  // G4_CernFLUKAHadronInelastic_FTFP_BERT_h
+#endif  // G4_USE_FLUKA
+
+//**************************************************

--- a/scripts/ATLTileCalTB_HTCondor_11.1.ref05.sh
+++ b/scripts/ATLTileCalTB_HTCondor_11.1.ref05.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+cd /afs/cern.ch/work/l/lopezzot/Fellow/FLUKACERN/ATLTileCalTB-build
+
+export ROOT_VERSION="6.24.06"
+export ROOT_PLATFORM="x86_64-centos7-gcc48-opt"
+export G4GCC_VERSION="10"
+export G4GCC_PLATFORM="x86_64-centos7-gcc10-opt"
+export GEANT4_VERSION="11.1.ref05"
+export GEANT4_PLATFORM="x86_64-centos7-gcc10-optdeb-MT"
+export GCC_VERSION="10"
+export GCC_PLATFORM="x86_64-centos7-gcc10-opt"
+
+source ./ATLTileCalTB_cvmfs_setup.sh
+./ATLTileCalTB -m TBrun_all.mac -t 12 -p FTFP_BERT

--- a/scripts/ATLTileCalTB_HTCondor_11.1.ref05.sh
+++ b/scripts/ATLTileCalTB_HTCondor_11.1.ref05.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-cd /afs/cern.ch/work/l/lopezzot/Fellow/FLUKACERN/ATLTileCalTB-build
 
 export ROOT_VERSION="6.24.06"
 export ROOT_PLATFORM="x86_64-centos7-gcc48-opt"
@@ -11,4 +10,3 @@ export GCC_VERSION="10"
 export GCC_PLATFORM="x86_64-centos7-gcc10-opt"
 
 source ./ATLTileCalTB_cvmfs_setup.sh
-./ATLTileCalTB -m TBrun_all.mac -t 12 -p FTFP_BERT

--- a/scripts/ATLTileCalTB_lxplus_11.1.ref05.sh
+++ b/scripts/ATLTileCalTB_lxplus_11.1.ref05.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+export ROOT_VERSION="6.24.06"
+export ROOT_PLATFORM="x86_64-centos7-gcc48-opt"
+export G4GCC_VERSION="10"
+export G4GCC_PLATFORM="x86_64-centos7-gcc10-opt"
+export GEANT4_VERSION="11.1.ref05"
+export GEANT4_PLATFORM="x86_64-centos7-gcc10-optdeb-MT"
+export GCC_VERSION="10"
+export GCC_PLATFORM="x86_64-centos7-gcc10-opt"
+
+source ./ATLTileCalTB_cvmfs_setup.sh
+
+export CC=$(command -v gcc)
+export CXX=$(command -v g++)
+cmake3 ../ATLTileCalTB $@
+make -j$(nproc)
+

--- a/src/FLUKAHadronInelasticPhysics.cc
+++ b/src/FLUKAHadronInelasticPhysics.cc
@@ -1,0 +1,219 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+#ifdef G4_USE_FLUKA
+
+
+#include "FLUKAHadronInelasticPhysics.hh"
+
+// G4
+#include "G4MesonConstructor.hh"
+#include "G4BaryonConstructor.hh"
+#include "G4ShortLivedConstructor.hh"
+// G4
+#include "G4ParticleDefinition.hh"
+#include "G4PhysicsListHelper.hh"
+// G4
+#include "G4HadParticles.hh"
+#include "G4HadronicParameters.hh"
+// G4
+#include "G4NeutronCaptureProcess.hh"
+#include "G4NeutronRadCapture.hh"
+// G4
+#include "G4HadronInelasticProcess.hh"
+
+#include "build_G4_process_helpers.hh"
+
+#include "FLUKAInelasticScatteringXS.hh"
+#include "FLUKANuclearInelasticModel.hh"
+
+
+// DEBUG: CHERRY PICK FTFP_BERT XS / MODELS INSTEAD
+//#include "G4BGGNucleonInelasticXS.hh"
+//#include "G4TheoFSGenerator.hh"
+//#include "G4GeneratorPrecompoundInterface.hh"
+//#include "G4FTFModel.hh"
+//#include "G4ExcitedStringDecay.hh"
+//#include "G4QuasiElasticChannel.hh"
+
+
+// ***************************************************************************
+// Construct hadron inelastic physics processes with FLUKA.CERN XS and models.
+// ***************************************************************************
+FLUKAHadronInelasticPhysics::FLUKAHadronInelasticPhysics(G4int verbose)
+:  G4VPhysicsConstructor("hInelastic FLUKA")
+{
+  if (verbose > 1) { 
+    G4cout << "### FLUKA Hadron Inelastic Physics" << G4endl;
+  }
+
+  const auto param = G4HadronicParameters::Instance();
+  param->SetEnableBCParticles(true);
+}
+
+
+// ***************************************************************************
+// Construct particles. 
+// ***************************************************************************
+void FLUKAHadronInelasticPhysics::ConstructParticle() {
+  G4MesonConstructor pMesonConstructor;
+  pMesonConstructor.ConstructParticle();
+
+  G4BaryonConstructor pBaryonConstructor;
+  pBaryonConstructor.ConstructParticle();
+
+  G4ShortLivedConstructor pShortLivedConstructor;
+  pShortLivedConstructor.ConstructParticle();  
+}
+
+
+// ***************************************************************************
+// For each particle of interest, 
+// processes are created, assigned XS and models, and registered to the process manager.
+//
+// IMPORTANT NB: The XS (G4VCrossSectionDataSet), models (G4HadronicInteraction), 
+// and even processes (G4HadronInelasticProcess) 
+// are constructed in a similar way as for any other G4 physics list in G4 source code.
+// They do not seem to be OWNED by the G4CrossSectionDataStore, G4EnergyRangeManager 
+// and G4ProcessManager respectively, HENCE THEY ARE NEVER DELETED
+// (true for ANY physics list).
+// Should not matter too much though, because the destructions 
+// should have happened at the very end of the run anyway.
+// ***************************************************************************
+void FLUKAHadronInelasticPhysics::ConstructProcess() {
+
+  const auto helper = G4PhysicsListHelper::GetPhysicsListHelper();
+
+  // FLUKA hadron - nucleus inelastic XS
+  const auto flukaInelasticScatteringXS = new FLUKAInelasticScatteringXS();
+
+  // FLUKA hadron - nucleus model
+  const auto flukaModel = new FLUKANuclearInelasticModel();
+
+
+  // PROTON
+  build_G4_process_helpers::buildInelasticProcess(G4Proton::Proton(),
+                                                  helper,
+                                                  flukaInelasticScatteringXS,
+                                                  flukaModel);
+	
+  // DEBUG: CHERRY PICK G4 XS / MODELS INSTEAD
+  /*auto protonInelasticProcess = new G4HadronInelasticProcess("protonInelastic", G4Proton::Proton());
+    helper->RegisterProcess(protonInelasticProcess, G4Proton::Proton());	
+    protonInelasticProcess->AddDataSet(flukaInelasticScatteringXS);
+    //auto BGG = new G4BGGNucleonInelasticXS(G4Proton::Proton());
+    //protonInelasticProcess->AddDataSet(BGG);
+
+    protonInelasticProcess->RegisterMe(flukaModel);
+    //auto theModel = new G4TheoFSGenerator("FTFP");
+    //auto theStringModel = new G4FTFModel();
+    //theStringModel->SetFragmentationModel(new G4ExcitedStringDecay());
+    //theModel->SetHighEnergyGenerator(theStringModel);
+    //theModel->SetQuasiElasticChannel(new G4QuasiElasticChannel());
+    //auto theCascade = new G4GeneratorPrecompoundInterface();
+    //theModel->SetTransport(theCascade);
+    //theModel->SetMinEnergy(G4HadronicParameters::Instance()->GetMinEnergyTransitionFTF_Cascade());
+    //theModel->SetMaxEnergy(G4HadronicParameters::Instance()->GetMaxEnergy());
+    //protonInelasticProcess->RegisterMe(theModel);
+    */
+
+  // NEUTRON
+  const auto neutron = G4Neutron::Neutron();
+
+  // NEUTRON INELASTIC
+  const auto neutronInelasticProcess = new G4HadronInelasticProcess("neutronInelastic", neutron);
+  // NB: No XS is set by default in the G4HadronInelasticProcess constructor.
+  helper->RegisterProcess(neutronInelasticProcess, neutron);
+
+  // Also non-HP: FLUKA neutron inelastic
+  // IMPORTANT NB: Since flukaInelasticScatteringXS is SetForAllAtomsAndEnergies,
+  // it needs to be set first (would erase any previously defined dataset, 
+  // see G4CrossSectionDataStore::AddDataSet).
+  neutronInelasticProcess->AddDataSet(flukaInelasticScatteringXS);
+  const auto flukaNeutronModel = new FLUKANuclearInelasticModel();
+  neutronInelasticProcess->RegisterMe(flukaNeutronModel);
+
+  // TO DO: Not elegant to have G4 neutron capture and fission included in FLUKA inelastic. 
+  // Create a Physics constructor just for it? 
+  // (NB: CANNOT use the neutron builders, 
+  // because they would ALSO create a G4HadronInelasticProcess, while we use the FLUKA one).
+
+  // NEUTRON CAPTURE
+  const auto neutronCaptureProcess = new G4NeutronCaptureProcess();
+  // NB: XS (G4NeutronCaptureXS) is already added, in G4NeutronCaptureProcess constructor.
+  helper->RegisterProcess(neutronCaptureProcess, neutron);
+  const auto neutronRadCaptureModel = new G4NeutronRadCapture();
+  neutronCaptureProcess->RegisterMe(neutronRadCaptureModel);
+
+  // NO NEUTRON FISSION
+
+  // PI+, PI-
+  build_G4_process_helpers::buildInelasticProcess(G4PionPlus::PionPlus(),
+                                                  helper,
+                                                  flukaInelasticScatteringXS,
+                                                  flukaModel);
+  build_G4_process_helpers::buildInelasticProcess(G4PionMinus::PionMinus(),
+                                                  helper,
+                                                  flukaInelasticScatteringXS,
+                                                  flukaModel);
+
+
+  // KAONS
+  build_G4_process_helpers::buildInelasticProcessForEachParticle(G4HadParticles::GetKaons(), 
+                                                                 helper,
+                                                                 flukaInelasticScatteringXS,
+                                                                 flukaModel);
+
+
+  const auto param = G4HadronicParameters::Instance();
+  if (param->GetMaxEnergy() > param->EnergyThresholdForHeavyHadrons()) {
+
+    // HYPERONS, ANTI-HYPERONS
+    build_G4_process_helpers::buildInelasticProcessForEachParticle(G4HadParticles::GetHyperons(),
+                                                                   helper,
+                                                                   flukaInelasticScatteringXS,
+                                                                   flukaModel);
+    build_G4_process_helpers::buildInelasticProcessForEachParticle(G4HadParticles::GetAntiHyperons(),
+                                                                   helper,
+                                                                   flukaInelasticScatteringXS,
+                                                                   flukaModel);
+
+    // LIGHT ANTI-IONS: PBAR, NBAR, ANTI LIGHT IONS
+    build_G4_process_helpers::buildInelasticProcessForEachParticle(G4HadParticles::GetLightAntiIons(),
+                                                                   helper,
+                                                                   flukaInelasticScatteringXS,
+                                                                   flukaModel);
+
+    // B-, C- BARYONS AND MESONS
+    if (G4HadronicParameters::Instance()->EnableBCParticles() ) {
+      build_G4_process_helpers::buildInelasticProcessForEachParticle(G4HadParticles::GetBCHadrons(),
+                                                                     helper,
+                                                                     flukaInelasticScatteringXS,
+                                                                     flukaModel);
+    }
+  }
+}
+
+
+#endif // G4_USE_FLUKA

--- a/src/G4_CernFLUKAHadronInelastic_FTFP_BERT.cc
+++ b/src/G4_CernFLUKAHadronInelastic_FTFP_BERT.cc
@@ -1,0 +1,91 @@
+//**************************************************
+// \file G4_CernFLUKAHadronInelastic_FTFP_BERT.cc
+// \brief: Implementation of
+// G4_CernFLUKAHadronInelastic_FTFP_BERT class
+// \author: Lorenzo Pezzotti (CERN EP-SFT-sim)
+//          @lopezzot
+// \start date: 2 June 2023
+//**************************************************
+
+/*Note:
+This class is a customization of the FTFP_BERT physics list
+to use the HadronInelastic process of FLUKA via the
+FLUKA interface included in geant4-11.1.ref05.
+*/
+
+#ifdef G4_USE_FLUKA
+
+// Includers from project files
+//
+#  include "G4_CernFLUKAHadronInelastic_FTFP_BERT.hh"
+#  include "FLUKAHadronInelasticPhysics.hh"
+
+// Includers from Geant4
+//
+#  include "G4DecayPhysics.hh"
+#  include "G4EmExtraPhysics.hh"
+#  include "G4EmStandardPhysics.hh"
+#  include "G4HadronElasticPhysics.hh"
+#  include "G4IonPhysics.hh"
+#  include "G4NeutronTrackingCut.hh"
+#  include "G4StoppingPhysics.hh"
+#  include "G4ios.hh"
+#  include "globals.hh"
+
+#  include <iomanip>
+// #include "G4HadronPhysicsFTFP_BERT.hh" //replaced by FLUKAHadronInelasticPhysics.hh
+
+// Includers from FLUKA interface
+//
+#  include "fluka_interface.hh"
+
+G4_CernFLUKAHadronInelastic_FTFP_BERT::G4_CernFLUKAHadronInelastic_FTFP_BERT(G4int ver)
+{
+  if (ver > 0) {
+    G4cout << "Geant4 Physics List simulation engine: FTFP_BERT PL customized with "
+              "FLUKAHadronInelasticPhysicsConstructor"
+           << G4endl;
+    G4cout << G4endl;
+  }
+
+  defaultCutValue = 0.7 * CLHEP::mm;
+  SetVerboseLevel(ver);
+
+  // EM Physics
+  RegisterPhysics(new G4EmStandardPhysics(ver));
+
+  // Synchroton Radiation & GN Physics
+  RegisterPhysics(new G4EmExtraPhysics(ver));
+
+  // Decays
+  RegisterPhysics(new G4DecayPhysics(ver));
+
+  // Hadron Elastic scattering
+  RegisterPhysics(new G4HadronElasticPhysics(ver));
+
+  // Hadron Physics
+  // RegisterPhysics(  new G4HadronPhysicsFTFP_BERT(ver));
+  RegisterPhysics(new FLUKAHadronInelasticPhysics(ver));
+
+  // Stopping Physics
+  RegisterPhysics(new G4StoppingPhysics(ver));
+
+  // Ion Physics
+  RegisterPhysics(new G4IonPhysics(ver));
+
+  // Neutron tracking cut
+  RegisterPhysics(new G4NeutronTrackingCut(ver));
+
+  // IMPORTANT: Initialize the FLUKA interface here.
+  // Both activation switches should be set to TRUE to provide the most comprehensive results.
+  // NB: COMPARISON WITH G4 DOES NOT SEEM MEANINGFUL
+  // WHEN COALESCENCE IS ACTIVATED IN BOTH FLUKA AND G4.
+  // Freedom to choose & see the effect of these switches is hence provided here.
+  const G4bool activateCoalescence = true;
+  const G4bool activateHeavyFragmentsEvaporation = true;
+  fluka_interface::initialize(activateCoalescence, activateHeavyFragmentsEvaporation);
+}
+
+#endif  // G4_USE_FLUKA
+
+//**************************************************


### PR DESCRIPTION
This PR is prepared to use the code with the Fluka.Cern interface as in geant4-11.1.ref05.
It includes:
- Config files for lxplus and HTCondor usage with geant4-11.1.ref05 (cd13fa2e341023ce7d3f90f798c501acefe04405 27283db014883685f7c0b1951808dd22f7b04f97)
- CMake adaptation to use the Fluka.Cern interface (926f0776453d39eb81ea307c16212cd7c7d4571e)
- Make compilation against ROOT OFF by default (dadf9eaed3b8510501f67cecc9073691939e1fa4)
- Add doc for Fluka.Cern usage (8072abfd0ee102fe024c3d7b01ee13437ff137bb)
- Add Fluka.Cern code and custom FTFP_BERT PL (eade47c771db653a6bc1c8e447a4e4bf93cbee13)
- Add table for results not in geant-val

This code will be used for FTFP_BERT comparison with and without Fluka.Cern interface.