### PR TITLE
Add 1.2_3 data in table

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Ask authors for access to datasets. Results are deployed on Geant Val.
 
 | ATLTileCalTB     | Reproduce data | Reproduce analysis | Comments     |
 | -------------    | ----------     | -----------        | -----------  |
+| v1.2 <br /> Dataset #3 <br /> Geant4.10.6.3 (modified) <br /> tag 1.2_3 <br /> FTFP_BERT <br /> Created on 3/9/2023 | `./ATLTileCalTB -m TBrun_all.mac -p FTFP_BERT` | `root TBrun_all.C` | Results to test the new FTF parameters by A. Ribon to fix the fluctuations disprepancy with respect to ATLAS data. Excitation energy per wounded nucleon set to 50 MeV. |
 | v1.2 <br /> Dataset #2 <br /> Geant4.10.6.3 (modified) <br /> tag 1.2_2 <br /> FTFP_BERT <br /> Created on 17/8/2023 | `./ATLTileCalTB -m TBrun_all.mac -p FTFP_BERT` | `root TBrun_all.C` | Results to test the new FTF parameters by A. Ribon to fix the fluctuations disprepancy with respect to ATLAS data. |
 | v1.2 <br /> Dataset #1 <br /> Geant4 11.1.ref05 & fluka4-3.3 <br /> tag 1.2_1 <br /> FTFP_BERT and FTFP_BERT+fluka.cern-interface <br /> Created on 5/8/2023 | `./ATLTileCalTB -m TBrun_all.mac -p FTFP_BERT` | `root FLUKA_comparison.C` | Data produced to compare results between Geant4 and FLUKA by using the Fluka.Cern interface. FTFP_BERT was used and compared to its Fluka.Cern customized version available in this repo. The interface was compiled as provided in the Geant4 11.1.ref05 examples. [See how to use it](#use-flukacern-hadron-inelastic-process). |
 </p>


### PR DESCRIPTION
Add 1.2_3 data in table of results. Data to study the energy resolution with excitation energy per wounded nucleon set to 50 MeV w.r.t. 1.2_2 data.