### PR TITLE
Fix bug in SpectrumAnalyzer usage

### DIFF
--- a/src/ATLTileCalTBRunAction.cc
+++ b/src/ATLTileCalTBRunAction.cc
@@ -116,9 +116,6 @@ void ATLTileCalTBRunAction::EndOfRunAction(const G4Run* /*run*/) {
     analysisManager->Write();
     analysisManager->CloseFile();
     
-    #ifdef ATLTileCalTB_LEAKANALYSIS
-    SpectrumAnalyzer::GetInstance()->ClearNtupleID();
-    #endif
 }
 
 //**************************************************


### PR DESCRIPTION
Do not reset ntupleID at the end of the run. If a macro has multiple runs the ntupleID becomes buggy.