### PR TITLE
Use IsMaster() in BeginOfRunAction

### DIFF
--- a/src/ATLTileCalTBRunAction.cc
+++ b/src/ATLTileCalTBRunAction.cc
@@ -45,18 +45,6 @@ ATLTileCalTBRunAction::ATLTileCalTBRunAction( ATLTileCalTBEventAction* eventActi
     //
     auto analysisManager = G4AnalysisManager::Instance();
 
-    //Print useful information
-    //
-    if (IsMaster()) {
-        G4cout << "Using " << analysisManager->GetType() << G4endl;
-        #ifdef ATLTileCalTB_PulseOutput
-        G4cout << "Creating pulse plots" << G4endl;
-        #endif
-        #ifdef ATLTileCalTB_NoNoise
-        G4cout << "Electronic noise disabled" << G4endl;
-        #endif
-    }
-
     analysisManager->SetVerboseLevel(1);
     analysisManager->SetNtupleMerging(true);
 
@@ -97,6 +85,18 @@ void ATLTileCalTBRunAction::BeginOfRunAction(const G4Run* run) {
     //G4RunManager::GetRunManager()->SetRandomNumberStore(true);
   
     auto analysisManager = G4AnalysisManager::Instance();
+
+    //Print useful information
+    //
+    if (IsMaster()) {
+        G4cout << "Using " << analysisManager->GetType() << G4endl;
+        #ifdef ATLTileCalTB_PulseOutput
+        G4cout << "Creating pulse plots" << G4endl;
+        #endif
+        #ifdef ATLTileCalTB_NoNoise
+        G4cout << "Electronic noise disabled" << G4endl;
+        #endif
+    }
 
     std::string runnumber = std::to_string( run->GetRunID() );
     G4String fileName = "ATLTileCalTBout_Run" + runnumber + ".root";


### PR DESCRIPTION
Do not use IsMaster() in RunAction constructor as IsMaster() does not return a correct value until that RunAction object is set to a RunManager. Reported [here](https://twiki.cern.ch/twiki/bin/view/Geant4/QuickMigrationGuideForGeant4V10).

@stephanlachnit just in case you are using it in the RunAction constructor of other applications :)
